### PR TITLE
fix: deterministic coverage-report generation

### DIFF
--- a/internal/discovery/buildregistry_internal_test.go
+++ b/internal/discovery/buildregistry_internal_test.go
@@ -10,6 +10,76 @@ import (
 	"github.com/example/tfprovidertest/pkg/config"
 )
 
+// TestBuildRegistryFromFiles_DeterministicAcrossInputOrder guards against the
+// report-nondeterminism follow-up: when the same canonical resource is defined
+// in more than one file (e.g. tls's private_key as both an ephemeral and a
+// managed resource), the registry keeps the last-registered definition, so the
+// reported FILE column depended on file-processing order (Go map iteration in
+// the CLI's parser.ParseDir). BuildRegistryFromFiles now sorts files by name
+// up front, so the winner is deterministic regardless of input slice order.
+func TestBuildRegistryFromFiles_DeterministicAcrossInputOrder(t *testing.T) {
+	srcs := map[string]string{
+		"ephemeral_widget.go": `
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+type widgetEphemeralResource struct{}
+
+func (r *widgetEphemeralResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_widget"
+}
+
+func (r *widgetEphemeralResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {}
+`,
+		"resource_widget.go": `
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+type widgetResource struct{}
+
+func (r *widgetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_widget"
+}
+
+func (r *widgetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {}
+`,
+	}
+
+	winnerFor := func(order []string) string {
+		fset := token.NewFileSet()
+		var files []*ast.File
+		for _, name := range order {
+			f, err := parser.ParseFile(fset, name, srcs[name], parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse %s: %v", name, err)
+			}
+			files = append(files, f)
+		}
+		reg := BuildRegistryFromFiles(files, fset, config.DefaultSettings())
+		def := reg.GetResourceOrDataSource("resource:widget")
+		if def == nil {
+			t.Fatalf("resource:widget not discovered for order %v", order)
+		}
+		return def.FilePath
+	}
+
+	a := winnerFor([]string{"ephemeral_widget.go", "resource_widget.go"})
+	b := winnerFor([]string{"resource_widget.go", "ephemeral_widget.go"})
+	if a != b {
+		t.Errorf("FILE column nondeterministic: order A -> %q, order B -> %q (want identical)", a, b)
+	}
+}
+
 func keysOf(m map[string]*registry.ResourceInfo) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/internal/discovery/parser.go
+++ b/internal/discovery/parser.go
@@ -10,6 +10,7 @@ import (
 	"go/token"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
@@ -1298,6 +1299,18 @@ func BuildRegistry(pass *analysis.Pass, settings config.Settings) *registry.Reso
 // function removes that divergence.
 func BuildRegistryFromFiles(files []*ast.File, fset *token.FileSet, settings config.Settings) *registry.ResourceRegistry {
 	reg := registry.NewResourceRegistry()
+
+	// Process files in a deterministic (filename-sorted) order. The CLI collects
+	// files from parser.ParseDir, which returns them in a map with nondeterministic
+	// iteration order; that order leaked into the report whenever the same
+	// canonical resource was defined in more than one file (RegisterResource keeps
+	// the last write) and into the order tests were appended per resource. Sorting
+	// here makes both deterministic for every caller. We copy the slice so we do
+	// not mutate the caller's ordering (e.g. the analysis pass's Files).
+	files = append([]*ast.File(nil), files...)
+	sort.SliceStable(files, func(i, j int) bool {
+		return fset.Position(files[i].Pos()).Filename < fset.Position(files[j].Pos()).Filename
+	})
 
 	// Discover local test helpers first.
 	localHelpers := findLocalTestHelpers(files, fset)

--- a/validation/AGENTS.md
+++ b/validation/AGENTS.md
@@ -55,9 +55,17 @@ discovery, matching, or coverage behavior changes.
 
 ## Known issues
 
-- **Nondeterministic reports** for providers with a same-named resource across
-  multiple files (e.g. `tls` `private_key`). The FILE column varies between runs
-  via map iteration order. Do not refresh affected reports until fixed. See the
-  follow-up task and `VALIDATION_REPORT.md` addendum.
+- ~~Nondeterministic reports for same-named multi-file resources~~ **FIXED.**
+  `BuildRegistryFromFiles` now sorts files by name before processing, so the
+  FILE column and per-resource test order are stable across runs (the CLI
+  previously inherited `parser.ParseDir`'s map iteration order). `tls`, `aap`,
+  etc. now regenerate deterministically.
+- **Resource double-counting on central-map providers** (`awscc`, and to a
+  lesser extent `google-beta`): regenerating these reports shows roughly 2x the
+  real resource/data-source counts (e.g. `awscc` 1006 -> 2265 resources). A
+  resource registered both by the central-map/factory strategy and by
+  per-resource discovery lands under two keys. Because of this, **do not refresh
+  `awscc`/`google-beta` reports until the double-count is fixed** — the numbers
+  are not yet trustworthy. Tracked as a separate follow-up.
 - `terraform-provider-random` is absent; its `specs/reports/random-report.txt`
   is an error stub. Add the source or remove the stub.


### PR DESCRIPTION
## Summary

Fixes nondeterministic coverage-report generation. Reports varied between runs for providers that define the same canonical resource in more than one file (e.g. `tls`'s `private_key`, present as both an ephemeral and a managed resource): the reported FILE column and per-resource test order changed run-to-run.

## Root cause

`RegisterResource` keeps the last write for a given `(Kind, Name)`, and the CLI fed files to `BuildRegistryFromFiles` in `parser.ParseDir`'s **map iteration order**. So which duplicate "won" the FILE column, and the order tests were appended per resource, were both nondeterministic. (The golangci-lint plugin path was already stable because `analysis.Pass.Files` is ordered.)

## Fix

Sort files by name at the top of `BuildRegistryFromFiles` (copying the slice so the analysis pass's ordering is not mutated). One fix covers both the plugin and CLI callers.

- `tls` and `aap` now regenerate **byte-identically** across runs (verified 5x / 3x).
- `powerhmc`/`time` reports are unchanged (single-file-per-resource).

## Test

`TestBuildRegistryFromFiles_DeterministicAcrossInputOrder` feeds the same two files in both slice orders and asserts the same winner (fails before the fix, passes after).

## Note: a separate bug surfaced (not fixed here)

Regenerating reports for **awscc** revealed resource/data-source counts roughly doubling (1006→2265 resources). This is an awscc-specific over-discovery bug (the report's 6282 definitions exceed even awscc's 3695 total registry factory calls), distinct from this change. `google-beta` totals are stable, so it is not a general issue. Documented in `validation/AGENTS.md`; `awscc`/`google-beta` reports are intentionally not refreshed until it is fixed.

## Post-Deploy Monitoring & Validation

No runtime/production impact (developer linter). Validation: `go test ./...` green, and `scripts/regenerate-reports.sh tls aap` now produces identical output on repeat runs. Failure signal: a non-empty diff when regenerating a deterministic provider's report twice.
