### PR TITLE
fix: stop double-counting registry-factory (AWSCC) resources

### DIFF
--- a/internal/discovery/parser.go
+++ b/internal/discovery/parser.go
@@ -633,6 +633,59 @@ func (r *RegistryFactoryStrategy) Discover(file *ast.File, fset *token.FileSet, 
 	return resources
 }
 
+// markRegistryFactoryFuncs records the factory function name of every
+// registry.Add{Resource,DataSource,ListResource}Factory call in the file into
+// state.ProcessedFactoryFuncs. ReturnTypeStrategy skips functions already in
+// that set, so those resources are discovered only once — by
+// RegistryFactoryStrategy, under their authoritative Terraform type name —
+// rather than also as a stripped-name duplicate (finding #11 / AWSCC).
+func markRegistryFactoryFuncs(file *ast.File, state *DiscoveryState) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		callExpr, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := callExpr.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkgIdent, ok := sel.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "registry" {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "AddResourceFactory", "AddDataSourceFactory", "AddListResourceFactory":
+			if fn := extractFactoryFuncName(callExpr.Args); fn != "" {
+				state.ProcessedFactoryFuncs[fn] = true
+			}
+		}
+		return true
+	})
+}
+
+// extractFactoryFuncName returns the name of the factory function passed to a
+// registry.Add*Factory call. It handles a direct identifier
+// (AddResourceFactory("name", newFooResource)) and a single-level wrapper call
+// (AddListResourceFactory("name", generic.NewListResource(newFooResource))) by
+// returning the first identifier argument of the wrapper. Returns "" when no
+// factory function identifier can be determined.
+func extractFactoryFuncName(args []ast.Expr) string {
+	if len(args) < 2 {
+		return ""
+	}
+	switch a := args[1].(type) {
+	case *ast.Ident:
+		return a.Name
+	case *ast.CallExpr:
+		for _, inner := range a.Args {
+			if id, ok := inner.(*ast.Ident); ok {
+				return id.Name
+			}
+		}
+	}
+	return ""
+}
+
 // extractResourceName tries to extract the resource name from the factory function.
 // It first looks for Metadata method calls or TypeName assignments, then falls back to function name parsing.
 func (r *ReturnTypeStrategy) extractResourceName(funcDecl *ast.FuncDecl, file *ast.File, kind registry.ResourceKind) string {
@@ -900,6 +953,14 @@ func matchesNestedPattern(name, pattern string) bool {
 func parseResources(file *ast.File, fset *token.FileSet, filePath string) []*registry.ResourceInfo {
 	// Initialize shared discovery state
 	state := NewDiscoveryState()
+
+	// Pre-pass: mark every factory function referenced by a registry.Add*Factory
+	// call as already processed, so ReturnTypeStrategy does not also register a
+	// stripped-name guess (e.g. "analyzer" from newResourceAnalyzer) for a
+	// resource that RegistryFactoryStrategy will register under its authoritative
+	// Terraform type name (e.g. "awscc_accessanalyzer_analyzer"). Without this,
+	// AWSCC-style providers double-count every resource (finding #11).
+	markRegistryFactoryFuncs(file, state)
 
 	// Define strategies in execution order
 	strategies := []DiscoveryStrategy{

--- a/internal/discovery/registryfactory_internal_test.go
+++ b/internal/discovery/registryfactory_internal_test.go
@@ -1,0 +1,56 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/example/tfprovidertest/internal/registry"
+)
+
+// awsccResourceSrc mirrors terraform-provider-awscc's generated resource file
+// shape: an init() that calls registry.AddResourceFactory with the authoritative
+// Terraform type name, plus the factory function it references (which returns
+// resource.Resource). Both the RegistryFactoryStrategy (full name) and the
+// ReturnTypeStrategy (factory function -> stripped name) can see this resource.
+const awsccResourceSrc = `
+package accessanalyzer
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-awscc/internal/registry"
+)
+
+func init() {
+	registry.AddResourceFactory("awscc_accessanalyzer_analyzer", newResourceAnalyzer)
+}
+
+func newResourceAnalyzer(ctx context.Context) (resource.Resource, error) {
+	return &analyzerResource{}, nil
+}
+
+type analyzerResource struct{}
+`
+
+// TestRegistryFactory_NoDoubleCountWithReturnType pins finding #11: the awscc
+// double-count. A resource registered via registry.AddResourceFactory and also
+// reachable via its factory function's return type must be counted ONCE, under
+// the authoritative full name from the AddResourceFactory call — not twice
+// (once as the full name and once as the ReturnType-stripped name).
+func TestRegistryFactory_NoDoubleCountWithReturnType(t *testing.T) {
+	resources := parseResourcesFromSrc(t, "analyzer_resource_gen.go", awsccResourceSrc)
+
+	var resourceNames []string
+	for _, r := range resources {
+		if r.Kind == registry.KindResource {
+			resourceNames = append(resourceNames, r.Name)
+		}
+	}
+
+	if len(resourceNames) != 1 {
+		t.Fatalf("expected exactly 1 resource, got %d: %v", len(resourceNames), resourceNames)
+	}
+	if resourceNames[0] != "awscc_accessanalyzer_analyzer" {
+		t.Errorf("resource name = %q; want the authoritative %q", resourceNames[0], "awscc_accessanalyzer_analyzer")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes resource double-counting for AWSCC-style providers that register resources through `registry.Add*Factory(...)`. `awscc` reported roughly 2x its real counts (2265 resources / 4017 data sources); it now reports **1260 resources / 2224 data sources**, matching its 1269 `AddResourceFactory` / 2233 `AddDataSourceFactory` registrations.

## Root cause

Each AWSCC resource was discovered **twice** under different keys:
- `ReturnTypeStrategy` saw the factory function `newResourceAnalyzer` (returns `resource.Resource`) and registered a **stripped guess** (`analyzer` / `new_resource_analyzer`).
- `RegistryFactoryStrategy` saw `registry.AddResourceFactory("awscc_accessanalyzer_analyzer", newResourceAnalyzer)` and registered the **authoritative** Terraform type name.

Different names → no dedup → 2x. (`google-beta` etc. are unaffected because their central-map names match `Metadata`.)

## Fix

A pre-pass (`markRegistryFactoryFuncs`) records every `Add*Factory` factory-function name into `ProcessedFactoryFuncs` before the strategies run. `ReturnTypeStrategy` already skips functions in that set, so each resource is discovered once — by `RegistryFactoryStrategy`, under its authoritative name. `extractFactoryFuncName` handles a bare identifier and a single-level wrapper (`generic.NewListResource(fn)`).

The pre-pass is a **guaranteed no-op** for providers without `registry.Add*Factory` calls (verified: google-beta/hcp/aap unchanged), so blast radius is limited to AWSCC-style providers. awscc is now deterministic across runs.

## Test

`TestRegistryFactory_NoDoubleCountWithReturnType` reproduces the awscc shape (an `AddResourceFactory` call + its factory function) and asserts a single resource under the authoritative name. Fails before the fix (2 entries), passes after.

## Known issue uncovered (not fixed here)

While verifying, I found `google-beta` still produces different summary counts across runs (untested / CheckDestroy wobble; totals stable) — a **second** nondeterminism source in the test↔resource matching layer that the earlier file-sort fix (#10) did not address. Tracked as a follow-up; a full report refresh stays blocked on it. The reports are intentionally not refreshed in this PR.

## Post-Deploy Monitoring & Validation

No runtime impact (developer linter). Validation: `go test ./...` green; `awscc` report summary is stable across repeated `scripts/regenerate-reports.sh awscc` runs and matches its registration counts. Failure signal: awscc counts diverging from ~1260/2224, or a non-awscc provider's totals changing.
