### PR TITLE
refactor: type Linker.settings + remove dead matching helpers

### DIFF
--- a/internal/discovery/parser.go
+++ b/internal/discovery/parser.go
@@ -1438,7 +1438,7 @@ func BuildRegistryFromFiles(files []*ast.File, fset *token.FileSet, settings con
 
 	// PHASE 3: Link tests to resources, then classify tests so provider and
 	// function tests are excluded from orphan counts.
-	linker := matching.NewLinker(reg, &settings)
+	linker := matching.NewLinker(reg, settings)
 	linker.LinkTestsToResources()
 	linker.ClassifyAllTests()
 

--- a/internal/matching/linker.go
+++ b/internal/matching/linker.go
@@ -3,10 +3,10 @@ package matching
 
 import (
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/example/tfprovidertest/internal/registry"
+	"github.com/example/tfprovidertest/pkg/config"
 )
 
 // Linker associates test functions with resources using multiple strategies.
@@ -17,11 +17,11 @@ import (
 // 4. Fuzzy matching (lowest confidence, optional)
 type Linker struct {
 	registry *registry.ResourceRegistry
-	settings interface{} // Settings - using interface{} to avoid circular imports during migration
+	settings config.Settings
 }
 
 // NewLinker creates a new Linker instance.
-func NewLinker(registry *registry.ResourceRegistry, settings interface{}) *Linker {
+func NewLinker(registry *registry.ResourceRegistry, settings config.Settings) *Linker {
 	return &Linker{
 		registry: registry,
 		settings: settings,
@@ -270,41 +270,9 @@ func (l *Linker) LinkTestsToResources() {
 	}
 }
 
-// isFuzzyMatchingEnabled checks if fuzzy matching is enabled in settings
+// isFuzzyMatchingEnabled checks if fuzzy matching is enabled in settings.
 func (l *Linker) isFuzzyMatchingEnabled() bool {
-	// Try to cast settings to *config.Settings
-	// We use interface{} to avoid circular imports during migration
-	type settingsWithFuzzy interface {
-		GetEnableFuzzyMatching() bool
-	}
-
-	// First try the interface method if available
-	if s, ok := l.settings.(settingsWithFuzzy); ok {
-		return s.GetEnableFuzzyMatching()
-	}
-
-	// Fallback for direct struct access using reflection
-	if l.settings != nil {
-		// Check if it has EnableFuzzyMatching field
-		switch s := l.settings.(type) {
-		case *struct{ EnableFuzzyMatching bool }:
-			return s.EnableFuzzyMatching
-		default:
-			// Try via reflection if the type has EnableFuzzyMatching field
-			val := reflect.ValueOf(l.settings)
-			if val.Kind() == reflect.Ptr {
-				val = val.Elem()
-			}
-			if val.Kind() == reflect.Struct {
-				field := val.FieldByName("EnableFuzzyMatching")
-				if field.IsValid() && field.Kind() == reflect.Bool {
-					return field.Bool()
-				}
-			}
-		}
-	}
-
-	return false
+	return l.settings.EnableFuzzyMatching
 }
 
 // GetAllDefinitions retrieves all definitions from the registry

--- a/internal/matching/utils.go
+++ b/internal/matching/utils.go
@@ -2,7 +2,6 @@
 package matching
 
 import (
-	"fmt"
 	"go/ast"
 	"path/filepath"
 	"regexp"
@@ -267,11 +266,6 @@ func IsBaseClassFile(filePath string) bool {
 	return strings.HasPrefix(base, "base_") || strings.HasPrefix(base, "base.")
 }
 
-// isBaseClassFile is an unexported alias for backward compatibility
-func isBaseClassFile(filePath string) bool {
-	return IsBaseClassFile(filePath)
-}
-
 // IsSweeperFile checks if a file is a sweeper file that should be excluded.
 // Sweeper files are test infrastructure files for cleaning up resources after
 // acceptance tests. They follow the naming pattern *_sweeper.go.
@@ -360,15 +354,6 @@ func ShouldExcludeFileExported(filePath string, excludePaths []string) bool {
 	return shouldExcludeFile(filePath, excludePaths)
 }
 
-// FormatResourceLocation formats the resource location for enhanced issue reporting.
-// Returns a string like "Resource: /path/to/file.go:45"
-// Exported for use by external tools that need to format resource locations.
-func FormatResourceLocation(pass interface{}, resource interface{}) string {
-	// This is a placeholder - will be properly implemented after fixing imports
-	// The original signature uses *analysis.Pass and *ResourceInfo
-	return fmt.Sprintf("Resource: unknown")
-}
-
 // extractResourceName extracts the resource name from a type name.
 // For example: "WidgetResource" -> "widget", "HttpDataSource" -> "http", "JobAction" -> "job"
 func extractResourceName(typeName string) string {
@@ -379,148 +364,6 @@ func extractResourceName(typeName string) string {
 
 	// Convert CamelCase to snake_case
 	return toSnakeCase(name)
-}
-
-// hasRequiresReplace checks if a node contains RequiresReplace plan modifier
-func hasRequiresReplace(node ast.Node) bool {
-	found := false
-	ast.Inspect(node, func(n ast.Node) bool {
-		// Look for function calls like stringplanmodifier.RequiresReplace()
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-
-		// Check if the function name contains "RequiresReplace"
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-			if strings.Contains(sel.Sel.Name, "RequiresReplace") {
-				found = true
-				return false
-			}
-		}
-
-		return true
-	})
-	return found
-}
-
-// extractAttributes parses the schema attributes from a Schema() function body
-func extractAttributes(body *ast.BlockStmt) []interface{} {
-	var attributes []interface{}
-	if body == nil {
-		return attributes
-	}
-
-	// Find the schema.Schema composite literal
-	ast.Inspect(body, func(n ast.Node) bool {
-		// Look for CompositeLit that represents schema.Schema{}
-		compLit, ok := n.(*ast.CompositeLit)
-		if !ok {
-			return true
-		}
-
-		// Check if this is schema.Schema type
-		if sel, ok := compLit.Type.(*ast.SelectorExpr); ok {
-			if sel.Sel.Name != "Schema" {
-				return true
-			}
-		}
-
-		// Find the Attributes field in schema.Schema
-		for _, elt := range compLit.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				continue
-			}
-
-			// Check if this is the Attributes field
-			if ident, ok := kv.Key.(*ast.Ident); ok && ident.Name == "Attributes" {
-				// Parse the attributes map
-				if mapLit, ok := kv.Value.(*ast.CompositeLit); ok {
-					attributes = parseAttributesMap(mapLit)
-				}
-			}
-		}
-
-		return false // Don't recurse into nested schemas
-	})
-
-	return attributes
-}
-
-// parseAttributesMap parses the attributes map from a schema
-func parseAttributesMap(mapLit *ast.CompositeLit) []interface{} {
-	var attributes []interface{}
-
-	for _, elt := range mapLit.Elts {
-		kv, ok := elt.(*ast.KeyValueExpr)
-		if !ok {
-			continue
-		}
-
-		// Get attribute name
-		var attrName string
-		if lit, ok := kv.Key.(*ast.BasicLit); ok {
-			attrName = strings.Trim(lit.Value, `"`)
-		}
-
-		if attrName == "" {
-			continue
-		}
-
-		// Parse attribute properties
-		attr := map[string]interface{}{
-			"Name":        attrName,
-			"IsUpdatable": true, // Default to updatable unless RequiresReplace found
-		}
-
-		// Parse the attribute composite literal
-		if attrLit, ok := kv.Value.(*ast.CompositeLit); ok {
-			for _, attrElt := range attrLit.Elts {
-				attrKV, ok := attrElt.(*ast.KeyValueExpr)
-				if !ok {
-					continue
-				}
-
-				fieldName := ""
-				if ident, ok := attrKV.Key.(*ast.Ident); ok {
-					fieldName = ident.Name
-				}
-
-				switch fieldName {
-				case "Required":
-					if ident, ok := attrKV.Value.(*ast.Ident); ok {
-						attr["Required"] = ident.Name == "true"
-					}
-				case "Optional":
-					if ident, ok := attrKV.Value.(*ast.Ident); ok {
-						attr["Optional"] = ident.Name == "true"
-					}
-				case "Computed":
-					if ident, ok := attrKV.Value.(*ast.Ident); ok {
-						attr["Computed"] = ident.Name == "true"
-					}
-				case "PlanModifiers":
-					// Check if RequiresReplace is present
-					attr["IsUpdatable"] = !hasRequiresReplace(attrKV.Value)
-				case "Validators":
-					// Check for validators
-					if compLit, ok := attrKV.Value.(*ast.CompositeLit); ok {
-						attr["HasValidators"] = len(compLit.Elts) > 0
-					}
-				}
-			}
-
-			// Determine attribute type from the composite literal type
-			if sel, ok := attrLit.Type.(*ast.SelectorExpr); ok {
-				attr["Type"] = sel.Sel.Name
-			}
-		}
-
-		attributes = append(attributes, attr)
-	}
-
-	return attributes
 }
 
 // standardRequiresReplaceModifiers maps known plan modifier names that indicate RequiresReplace.


### PR DESCRIPTION
## Summary

Maintainability cleanup in `internal/matching` (follow-up #12), in two behavior-preserving refactors. No functional change: full suite green, awscc/powerhmc reports byte-identical before/after.

## 1. Type `Linker.settings` as `config.Settings`

`Linker.settings` was `interface{}` with a reflection-based `isFuzzyMatchingEnabled`, justified by a comment about avoiding circular imports "during migration". There is no cycle — `pkg/config` imports nothing internal, and `internal/matching` depends only on `internal/registry`.

Typed the field as `config.Settings` and read `EnableFuzzyMatching` directly, deleting the `settingsWithFuzzy` interface, the `reflect` fallback, and the `reflect` import. The discovery caller now passes settings by value (matching what `linker_test.go` already did); only one production call site changed (`&settings` → `settings`).

## 2. Remove dead duplicate helpers

Deleted unused functions left over from the package split:
- `isBaseClassFile` (unexported alias, no callers)
- `FormatResourceLocation` (placeholder returning a constant, no callers; frees the `fmt` import)
- `extractAttributes` + `parseAttributesMap` + `hasRequiresReplace` (a dead island — `extractAttributes` was the only entry point and was itself unused; the live `RequiresReplace*WithConfidence` functions are separate and remain)

## Not done here (deferred)

The genuinely shared helpers (`toSnakeCase`, `toTitleCase`, `shouldExcludeFile`, `ExtractResourceNameFromPath`) are duplicated between `internal/discovery` and `internal/matching` and **used in both**, so deduping them needs a shared `internal/fileutil` package (move ~7 functions, update both packages and the root tests). That's a larger, purely-organizational refactor with no behavior change — left as a follow-up rather than bundled here.

## Post-Deploy Monitoring & Validation

No runtime impact (developer linter). Validation: `go test ./...` green; `go vet ./...` clean; awscc/powerhmc reports unchanged. Failure signal: any report diff or fuzzy-matching behavior change (fuzzy is off by default).
