### PR TITLE
refactor: extract shared internal/fileutil package

### DIFF
--- a/internal/discovery/utils.go
+++ b/internal/discovery/utils.go
@@ -6,8 +6,8 @@ import (
 	"go/ast"
 	"path/filepath"
 	"strings"
-	"unicode"
 
+	"github.com/example/tfprovidertest/internal/fileutil"
 	"github.com/example/tfprovidertest/internal/registry"
 )
 
@@ -39,13 +39,7 @@ func getReceiverTypeName(recv *ast.FieldList) string {
 // extractResourceName extracts the resource name from a type name.
 // For example: "WidgetResource" -> "widget", "HttpDataSource" -> "http", "JobAction" -> "job"
 func extractResourceName(typeName string) string {
-	// Remove "Resource", "DataSource", or "Action" suffix
-	name := strings.TrimSuffix(typeName, "Resource")
-	name = strings.TrimSuffix(name, "DataSource")
-	name = strings.TrimSuffix(name, "Action")
-
-	// Convert CamelCase to snake_case
-	return toSnakeCase(name)
+	return fileutil.ExtractResourceName(typeName)
 }
 
 // isBaseClassType checks if a type name represents a base/infrastructure class
@@ -74,40 +68,12 @@ func isBaseClassType(typeName string) bool {
 
 // toSnakeCase converts CamelCase to snake_case (e.g., "MyResource" -> "my_resource")
 func toSnakeCase(s string) string {
-	var result strings.Builder
-	runes := []rune(s)
-	for i, r := range runes {
-		if i > 0 && unicode.IsUpper(r) {
-			// Add underscore before uppercase if:
-			// 1. Previous char is lowercase, OR
-			// 2. Next char exists and is lowercase (handles acronyms like "HTTPServer" -> "http_server")
-			prev := runes[i-1]
-			if unicode.IsLower(prev) || (i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
-				result.WriteRune('_')
-			}
-		}
-		result.WriteRune(unicode.ToLower(r))
-	}
-	return result.String()
+	return fileutil.SnakeCase(s)
 }
 
 // toTitleCase converts snake_case to TitleCase (e.g., "my_resource" -> "MyResource")
 func toTitleCase(s string) string {
-	var result strings.Builder
-	capitalizeNext := true
-	for _, r := range s {
-		if r == '_' {
-			capitalizeNext = true
-			continue
-		}
-		if capitalizeNext {
-			result.WriteRune(unicode.ToUpper(r))
-			capitalizeNext = false
-		} else {
-			result.WriteRune(r)
-		}
-	}
-	return result.String()
+	return fileutil.TitleCase(s)
 }
 
 // hasImportStateMethod reports whether the file declares an ImportState method
@@ -319,45 +285,26 @@ func hasRequiresReplace(node ast.Node) bool {
 // Base class files typically contain abstract base classes for resources.
 // They follow naming patterns: base_*.go or base.*.go
 func IsBaseClassFile(filePath string) bool {
-	base := filepath.Base(filePath)
-	return strings.HasPrefix(base, "base_") || strings.HasPrefix(base, "base.")
+	return fileutil.IsBaseClassFile(filePath)
 }
 
 // IsSweeperFile checks if a file is a sweeper file that should be excluded.
 // Sweeper files are test infrastructure files for cleaning up resources after
 // acceptance tests. They follow the naming pattern *_sweeper.go.
 func IsSweeperFile(filePath string) bool {
-	base := filepath.Base(filePath)
-	return strings.HasSuffix(base, "_sweeper.go")
+	return fileutil.IsSweeperFile(filePath)
 }
 
 // IsMigrationFile checks if a file is a state migration file that should be excluded.
 // Migration files are state migration utilities, not production resources. They follow
 // naming patterns: *_migrate.go, *_migration*.go, *_state_upgrader.go
 func IsMigrationFile(filePath string) bool {
-	base := filepath.Base(filePath)
-	return strings.HasSuffix(base, "_migrate.go") ||
-		strings.Contains(base, "_migration") ||
-		strings.HasSuffix(base, "_state_upgrader.go")
+	return fileutil.IsMigrationFile(filePath)
 }
 
 // shouldExcludeFile checks if a file path matches any of the exclude patterns
 func shouldExcludeFile(filePath string, excludePaths []string) bool {
-	for _, pattern := range excludePaths {
-		// Try matching the full path
-		if matched, _ := filepath.Match(pattern, filePath); matched {
-			return true
-		}
-		// Try matching just the base name
-		if matched, _ := filepath.Match(pattern, filepath.Base(filePath)); matched {
-			return true
-		}
-		// Try matching with Contains for patterns like "vendor/"
-		if strings.Contains(filePath, strings.TrimSuffix(pattern, "/")) {
-			return true
-		}
-	}
-	return false
+	return fileutil.ShouldExcludeFile(filePath, excludePaths)
 }
 
 // ExtractResourceNameFromPath extracts resource name from file path.

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,0 +1,99 @@
+// Package fileutil holds small, dependency-free string- and path-classification
+// helpers shared by the discovery and matching packages. These were previously
+// duplicated byte-for-byte in internal/discovery/utils.go and
+// internal/matching/utils.go; this package is the single source of truth.
+package fileutil
+
+import (
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// SnakeCase converts a CamelCase identifier to snake_case. It inserts an
+// underscore before an uppercase rune when the previous rune is lowercase or
+// the next rune is lowercase, so acronyms are handled (e.g. "HTTPServer" ->
+// "http_server").
+func SnakeCase(s string) string {
+	var result strings.Builder
+	runes := []rune(s)
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := runes[i-1]
+			if unicode.IsLower(prev) || (i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+				result.WriteRune('_')
+			}
+		}
+		result.WriteRune(unicode.ToLower(r))
+	}
+	return result.String()
+}
+
+// TitleCase converts a snake_case identifier to CamelCase.
+func TitleCase(s string) string {
+	var result strings.Builder
+	capitalizeNext := true
+	for _, r := range s {
+		if r == '_' {
+			capitalizeNext = true
+			continue
+		}
+		if capitalizeNext {
+			result.WriteRune(unicode.ToUpper(r))
+			capitalizeNext = false
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// ExtractResourceName strips a Resource/DataSource/Action suffix from a Go type
+// name and returns the snake_case resource name (e.g. "WidgetResource" ->
+// "widget", "HttpDataSource" -> "http").
+func ExtractResourceName(typeName string) string {
+	name := strings.TrimSuffix(typeName, "Resource")
+	name = strings.TrimSuffix(name, "DataSource")
+	name = strings.TrimSuffix(name, "Action")
+	return SnakeCase(name)
+}
+
+// IsBaseClassFile reports whether a file is a base-class file (base_*.go),
+// typically an abstract type that should not be treated as a resource.
+func IsBaseClassFile(filePath string) bool {
+	base := filepath.Base(filePath)
+	return strings.HasPrefix(base, "base_") || strings.HasPrefix(base, "base.")
+}
+
+// IsSweeperFile reports whether a file is a sweeper file (*_sweeper.go), test
+// infrastructure for cleaning up resources.
+func IsSweeperFile(filePath string) bool {
+	base := filepath.Base(filePath)
+	return strings.HasSuffix(base, "_sweeper.go")
+}
+
+// IsMigrationFile reports whether a file is a state-migration file.
+func IsMigrationFile(filePath string) bool {
+	base := filepath.Base(filePath)
+	return strings.HasSuffix(base, "_migrate.go") ||
+		strings.Contains(base, "_migration") ||
+		strings.HasSuffix(base, "_state_upgrader.go")
+}
+
+// ShouldExcludeFile reports whether a file path matches any of the given glob/
+// substring exclude patterns (matched against the full path, the base name, or
+// as a trailing-slash-trimmed substring).
+func ShouldExcludeFile(filePath string, excludePaths []string) bool {
+	for _, pattern := range excludePaths {
+		if matched, _ := filepath.Match(pattern, filePath); matched {
+			return true
+		}
+		if matched, _ := filepath.Match(pattern, filepath.Base(filePath)); matched {
+			return true
+		}
+		if strings.Contains(filePath, strings.TrimSuffix(pattern, "/")) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/fileutil/fileutil_test.go
+++ b/internal/fileutil/fileutil_test.go
@@ -1,0 +1,63 @@
+package fileutil
+
+import "testing"
+
+func TestSnakeCase(t *testing.T) {
+	cases := map[string]string{
+		"WidgetResource": "widget_resource",
+		"HTTPServer":     "http_server",
+		"systemConfig":   "system_config",
+		"":               "",
+	}
+	for in, want := range cases {
+		if got := SnakeCase(in); got != want {
+			t.Errorf("SnakeCase(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestTitleCase(t *testing.T) {
+	cases := map[string]string{
+		"sys_config": "SysConfig",
+		"widget":     "Widget",
+	}
+	for in, want := range cases {
+		if got := TitleCase(in); got != want {
+			t.Errorf("TitleCase(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestExtractResourceName(t *testing.T) {
+	cases := map[string]string{
+		"WidgetResource": "widget",
+		"HttpDataSource": "http",
+		"JobAction":      "job",
+	}
+	for in, want := range cases {
+		if got := ExtractResourceName(in); got != want {
+			t.Errorf("ExtractResourceName(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestClassifiers(t *testing.T) {
+	if !IsBaseClassFile("base_widget.go") || IsBaseClassFile("resource_widget.go") {
+		t.Error("IsBaseClassFile")
+	}
+	if !IsSweeperFile("compute_sweeper.go") || IsSweeperFile("resource_widget.go") {
+		t.Error("IsSweeperFile")
+	}
+	if !IsMigrationFile("resource_state_upgrader.go") || IsMigrationFile("resource_widget.go") {
+		t.Error("IsMigrationFile")
+	}
+}
+
+func TestShouldExcludeFile(t *testing.T) {
+	if !ShouldExcludeFile("a/b_sweeper.go", []string{"*_sweeper.go"}) {
+		t.Error("expected exclude by base-name glob")
+	}
+	if ShouldExcludeFile("a/resource.go", []string{"*_sweeper.go"}) {
+		t.Error("did not expect exclude")
+	}
+}

--- a/internal/matching/utils.go
+++ b/internal/matching/utils.go
@@ -6,7 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"unicode"
+
+	"github.com/example/tfprovidertest/internal/fileutil"
 )
 
 // TestFunctionPrefixes are the common prefixes used in test function names.
@@ -47,40 +48,12 @@ var TestFunctionSuffixes = []string{
 
 // toSnakeCase converts CamelCase to snake_case (e.g., "MyResource" -> "my_resource")
 func toSnakeCase(s string) string {
-	var result strings.Builder
-	runes := []rune(s)
-	for i, r := range runes {
-		if i > 0 && unicode.IsUpper(r) {
-			// Add underscore before uppercase if:
-			// 1. Previous char is lowercase, OR
-			// 2. Next char exists and is lowercase (handles acronyms like "HTTPServer" -> "http_server")
-			prev := runes[i-1]
-			if unicode.IsLower(prev) || (i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
-				result.WriteRune('_')
-			}
-		}
-		result.WriteRune(unicode.ToLower(r))
-	}
-	return result.String()
+	return fileutil.SnakeCase(s)
 }
 
 // toTitleCase converts snake_case to TitleCase (e.g., "my_resource" -> "MyResource")
 func toTitleCase(s string) string {
-	var result strings.Builder
-	capitalizeNext := true
-	for _, r := range s {
-		if r == '_' {
-			capitalizeNext = true
-			continue
-		}
-		if capitalizeNext {
-			result.WriteRune(unicode.ToUpper(r))
-			capitalizeNext = false
-		} else {
-			result.WriteRune(r)
-		}
-	}
-	return result.String()
+	return fileutil.TitleCase(s)
 }
 
 // testFuncPatterns matches various test function naming conventions.
@@ -262,45 +235,26 @@ func ExtractProviderFromFuncName(funcName string) string {
 // Base class files typically follow the naming pattern base_*.go and contain
 // abstract/base implementations that are not actual Terraform resources.
 func IsBaseClassFile(filePath string) bool {
-	base := filepath.Base(filePath)
-	return strings.HasPrefix(base, "base_") || strings.HasPrefix(base, "base.")
+	return fileutil.IsBaseClassFile(filePath)
 }
 
 // IsSweeperFile checks if a file is a sweeper file that should be excluded.
 // Sweeper files are test infrastructure files for cleaning up resources after
 // acceptance tests. They follow the naming pattern *_sweeper.go.
 func IsSweeperFile(filePath string) bool {
-	base := filepath.Base(filePath)
-	return strings.HasSuffix(base, "_sweeper.go")
+	return fileutil.IsSweeperFile(filePath)
 }
 
 // IsMigrationFile checks if a file is a state migration file that should be excluded.
 // Migration files are state migration utilities, not production resources. They follow
 // naming patterns: *_migrate.go, *_migration*.go, *_state_upgrader.go
 func IsMigrationFile(filePath string) bool {
-	base := filepath.Base(filePath)
-	return strings.HasSuffix(base, "_migrate.go") ||
-		strings.Contains(base, "_migration") ||
-		strings.HasSuffix(base, "_state_upgrader.go")
+	return fileutil.IsMigrationFile(filePath)
 }
 
 // shouldExcludeFile checks if a file path matches any of the exclude patterns
 func shouldExcludeFile(filePath string, excludePaths []string) bool {
-	for _, pattern := range excludePaths {
-		// Try matching the full path
-		if matched, _ := filepath.Match(pattern, filePath); matched {
-			return true
-		}
-		// Try matching just the base name
-		if matched, _ := filepath.Match(pattern, filepath.Base(filePath)); matched {
-			return true
-		}
-		// Try matching with Contains for patterns like "vendor/"
-		if strings.Contains(filePath, strings.TrimSuffix(pattern, "/")) {
-			return true
-		}
-	}
-	return false
+	return fileutil.ShouldExcludeFile(filePath, excludePaths)
 }
 
 // isTestFunction checks if a function name matches any of the test naming patterns.
@@ -357,13 +311,7 @@ func ShouldExcludeFileExported(filePath string, excludePaths []string) bool {
 // extractResourceName extracts the resource name from a type name.
 // For example: "WidgetResource" -> "widget", "HttpDataSource" -> "http", "JobAction" -> "job"
 func extractResourceName(typeName string) string {
-	// Remove "Resource", "DataSource", or "Action" suffix
-	name := strings.TrimSuffix(typeName, "Resource")
-	name = strings.TrimSuffix(name, "DataSource")
-	name = strings.TrimSuffix(name, "Action")
-
-	// Convert CamelCase to snake_case
-	return toSnakeCase(name)
+	return fileutil.ExtractResourceName(typeName)
 }
 
 // standardRequiresReplaceModifiers maps known plan modifier names that indicate RequiresReplace.


### PR DESCRIPTION
## Summary

Completes follow-up #12's deduplication (tracked as #14): extracts the helpers that were byte-identical duplicates in `internal/discovery/utils.go` and `internal/matching/utils.go` into a new shared `internal/fileutil` package. No behavior change — full suite green, awscc/google-beta/powerhmc reports byte-identical before/after.

## What moved

Seven dependency-free string/path classifiers, verified byte-identical across both packages before the move:

- `SnakeCase` (was `toSnakeCase`), `TitleCase` (was `toTitleCase`), `ExtractResourceName`
- `IsBaseClassFile`, `IsSweeperFile`, `IsMigrationFile`, `ShouldExcludeFile`

The canonical implementations now live once in `internal/fileutil`. Each package keeps a thin delegating wrapper (e.g. `func toSnakeCase(s string) string { return fileutil.SnakeCase(s) }`) so internal call sites and the package APIs that root tests exercise (`matching.IsSweeperFile`, `discovery.IsMigrationFile`, etc.) keep working unchanged. This single-sources the logic with zero call-site churn and no API break.

## Test

`internal/fileutil/fileutil_test.go` gives the new package direct coverage (SnakeCase acronym handling, TitleCase, ExtractResourceName, the file classifiers, ShouldExcludeFile globbing). The existing root tests continue to exercise the wrappers.

## Post-Deploy Monitoring & Validation

No runtime impact (developer linter). Validation: `go test ./...` green; `go vet ./...` clean; awscc/google-beta/powerhmc reports unchanged. Failure signal: any report diff.
